### PR TITLE
Limiting event records

### DIFF
--- a/src/__mocks__/useLoggableEventsApiMocks.js
+++ b/src/__mocks__/useLoggableEventsApiMocks.js
@@ -1,27 +1,52 @@
 import {
-  GET_USERS_EVENTS_AND_LABELS_QUERY,
-  CREATE_LOGGABLE_EVENT_MUTATION,
-  CREATE_TIMESTAMP_FOR_EVENT_MUTATION,
-  UPDATE_LOGGABLE_EVENT_DETAILS_MUTATION,
-  DELETE_LOGGABLE_EVENT_MUTATION,
-  CREATE_EVENT_LABEL_MUTATION,
-  UPDATE_EVENT_LABEL_MUTATION,
-  DELETE_EVENT_LABEL_MUTATION
+    GET_USERS_EVENTS_AND_LABELS_QUERY,
+    CREATE_LOGGABLE_EVENT_MUTATION,
+    CREATE_EVENT_RECORD_MUTATION,
+    UPDATE_LOGGABLE_EVENT_DETAILS_MUTATION,
+    DELETE_LOGGABLE_EVENT_MUTATION,
+    CREATE_EVENT_LABEL_MUTATION,
+    UPDATE_EVENT_LABEL_MUTATION,
+    DELETE_EVENT_LABEL_MUTATION
 } from '../utils/useLoggableEventsApi';
 
 export const GET_USERS_EVENTS_AND_LABELS_QUERY_MOCK_EMPTY = [
-  {
-    request: {
-      query: GET_USERS_EVENTS_AND_LABELS_QUERY,
-      variables: { userId: 'test-user' },
-    },
-    result: {
-      data: {
-        user: {
-          loggableEvents: [],
-          eventLabels: [],
+    {
+        request: {
+            query: GET_USERS_EVENTS_AND_LABELS_QUERY,
+            variables: { userId: 'test-user' }
         },
-      },
-    },
-  },
+        result: {
+            data: {
+                user: {
+                    loggableEvents: [],
+                    eventLabels: []
+                }
+            }
+        }
+    }
+];
+
+export const GET_USERS_EVENTS_AND_LABELS_QUERY_MOCK_ONE_LOGGABLE_EVENT = [
+    {
+        request: {
+            query: GET_USERS_EVENTS_AND_LABELS_QUERY,
+            variables: { userId: 'test-user' }
+        },
+        result: {
+            data: {
+                user: {
+                    loggableEvents: [
+                        {
+                            id: 'event-1',
+                            name: 'Test Event 1',
+                            active: true,
+                            warningThresholdInDays: 7,
+                            labels: []
+                        }
+                    ],
+                    eventLabels: []
+                }
+            }
+        }
+    }
 ];

--- a/src/components/EventCards/LoggableEventCard.tsx
+++ b/src/components/EventCards/LoggableEventCard.tsx
@@ -48,11 +48,11 @@ const DaysSinceLastEventDisplay = ({
     const daysSinceLastEvent = getNumberOfDaysBetweenDates(lastEventRecordDate, new Date());
     const isViolatingThreshold = warningThresholdInDays > 0 && daysSinceLastEvent >= warningThresholdInDays;
 
-    let content = <Typography variant="caption">Last event: {daysSinceLastEvent} days ago</Typography>;
+    let textToDisplay = `Last event: ${daysSinceLastEvent} days ago`;
     if (daysSinceLastEvent === 0) {
-        content = <Typography variant="caption">Last event: Today</Typography>;
+        textToDisplay = `Last event: Today`;
     } else if (daysSinceLastEvent === 1) {
-        content = <Typography variant="caption">Last event: Yesterday</Typography>;
+        textToDisplay = `Last event: Yesterday`;
     }
 
     return (
@@ -63,7 +63,7 @@ const DaysSinceLastEventDisplay = ({
             `}
         >
             <Stack direction="row" spacing={1}>
-                {content}
+                <Typography variant="caption">{textToDisplay}</Typography>
                 {isViolatingThreshold && <WarningAmberIcon color="error" fontSize="small" />}
             </Stack>
         </Box>
@@ -263,10 +263,12 @@ const LoggableEventCard = ({ eventId }: Props) => {
                             </Stack>
                         </ListItem>
                     </Collapse>
+
+                    <Typography variant="subtitle2">Records</Typography>
                     {timestamps.map((record: Date) => {
                         const isFutureDate = getNumberOfDaysBetweenDates(record, currDate) < 0;
                         return (
-                            <ListItem disablePadding key={record.toISOString()}>
+                            <ListItem disablePadding key={`${id}-${record.toISOString()}`}>
                                 <ListItemText
                                     css={
                                         isFutureDate
@@ -276,7 +278,7 @@ const LoggableEventCard = ({ eventId }: Props) => {
                                             : null
                                     }
                                 >
-                                    {record.toLocaleString('en-US')}
+                                    {record.toLocaleDateString('en-US')}
                                 </ListItemText>
                             </ListItem>
                         );

--- a/src/mocks/gqlMocks.js
+++ b/src/mocks/gqlMocks.js
@@ -1,28 +1,28 @@
 import {
-  GET_USERS_EVENTS_AND_LABELS_QUERY,
-  CREATE_LOGGABLE_EVENT_MUTATION,
-  CREATE_TIMESTAMP_FOR_EVENT_MUTATION,
-  UPDATE_LOGGABLE_EVENT_DETAILS_MUTATION,
-  DELETE_LOGGABLE_EVENT_MUTATION,
-  CREATE_EVENT_LABEL_MUTATION,
-  UPDATE_EVENT_LABEL_MUTATION,
-  DELETE_EVENT_LABEL_MUTATION
+    GET_USERS_EVENTS_AND_LABELS_QUERY,
+    CREATE_LOGGABLE_EVENT_MUTATION,
+    CREATE_EVENT_RECORD_MUTATION,
+    UPDATE_LOGGABLE_EVENT_DETAILS_MUTATION,
+    DELETE_LOGGABLE_EVENT_MUTATION,
+    CREATE_EVENT_LABEL_MUTATION,
+    UPDATE_EVENT_LABEL_MUTATION,
+    DELETE_EVENT_LABEL_MUTATION
 } from '../utils/useLoggableEventsApi';
 
 export const mocks = [
-  {
-    request: {
-      query: GET_USERS_EVENTS_AND_LABELS_QUERY,
-      variables: { userId: 'test-user' },
-    },
-    result: {
-      data: {
-        user: {
-          loggableEvents: [],
-          eventLabels: [],
+    {
+        request: {
+            query: GET_USERS_EVENTS_AND_LABELS_QUERY,
+            variables: { userId: 'test-user' }
         },
-      },
-    },
-  },
-  // Add more mocks for mutations as needed
+        result: {
+            data: {
+                user: {
+                    loggableEvents: [],
+                    eventLabels: []
+                }
+            }
+        }
+    }
+    // Add more mocks for mutations as needed
 ];

--- a/src/providers/LoggableEventsProvider.tsx
+++ b/src/providers/LoggableEventsProvider.tsx
@@ -195,11 +195,9 @@ const LoggableEventsProvider = ({ offlineMode, children }: Props) => {
                     return eventData;
                 }
 
-                const prevTimestamps = eventData.timestamps.slice(0, 4);
-
                 return {
                     ...eventData,
-                    timestamps: [...prevTimestamps, dateToAdd].sort(sortDateObjectsByNewestFirst)
+                    timestamps: [...eventData.timestamps, dateToAdd].sort(sortDateObjectsByNewestFirst)
                 };
             })
         );

--- a/src/providers/LoggableEventsProvider.tsx
+++ b/src/providers/LoggableEventsProvider.tsx
@@ -113,7 +113,7 @@ const LoggableEventsProvider = ({ offlineMode, children }: Props) => {
         fetchedLoggableEvents,
         fetchedEventLabels,
         submitCreateLoggableEvent,
-        submitCreateTimestampForEvent,
+        submitCreateEventRecord,
         submitUpdateLoggableEventDetails,
         submitDeleteLoggableEvent,
         submitCreateEventLabel,
@@ -195,14 +195,16 @@ const LoggableEventsProvider = ({ offlineMode, children }: Props) => {
                     return eventData;
                 }
 
+                const prevTimestamps = eventData.timestamps.slice(0, 4);
+
                 return {
                     ...eventData,
-                    timestamps: [...eventData.timestamps, dateToAdd].sort(sortDateObjectsByNewestFirst)
+                    timestamps: [...prevTimestamps, dateToAdd].sort(sortDateObjectsByNewestFirst)
                 };
             })
         );
 
-        await submitCreateTimestampForEvent(eventId, newEventDateTimeISOString);
+        await submitCreateEventRecord(eventId, newEventDateTimeISOString);
     };
 
     const updateLoggableEventDetails = async (updatedLoggableEvent: LoggableEvent) => {

--- a/src/utils/useLoggableEventsApi.tsx
+++ b/src/utils/useLoggableEventsApi.tsx
@@ -31,8 +31,8 @@ export const CREATE_LOGGABLE_EVENT_MUTATION = gql`
     }
 `;
 
-export const CREATE_TIMESTAMP_FOR_EVENT_MUTATION = gql`
-    mutation CreateTimestampForEvent($input: CreateTimestampForEventMutation!) {
+export const CREATE_EVENT_RECORD_MUTATION = gql`
+    mutation CreateEventRecord($input: CreateEventRecordMutation!) {
         createTimestampForEvent(input: $input) {
             id
         }
@@ -123,8 +123,8 @@ const useLoggableEventsApi = (offlineMode: boolean) => {
               });
           };
 
-    const [createTimestampForEventMutation] = useMutation(CREATE_TIMESTAMP_FOR_EVENT_MUTATION, mutationOptions);
-    const submitCreateTimestampForEvent = offlineMode
+    const [createTimestampForEventMutation] = useMutation(CREATE_EVENT_RECORD_MUTATION, mutationOptions);
+    const submitCreateEventRecord = offlineMode
         ? () => Promise.resolve({ data: { createTimestampForEvent: { id: null } } })
         : (eventId: string, timestampString: string) => {
               return createTimestampForEventMutation({
@@ -204,7 +204,7 @@ const useLoggableEventsApi = (offlineMode: boolean) => {
         fetchedEventLabels: fetchEventsAndLabelsData?.eventLabels || [],
         refetchEventsAndLabelsData,
         submitCreateLoggableEvent,
-        submitCreateTimestampForEvent,
+        submitCreateEventRecord,
         submitUpdateLoggableEventDetails,
         submitDeleteLoggableEvent,
         submitCreateEventLabel,


### PR DESCRIPTION
Limits displayed records to only the 5 most recent records, prevents recording the same date multiple times, and renamed `createTimestampForEvent` to `createEventRecord`

![image](https://github.com/user-attachments/assets/89f998dd-0dfd-4696-a371-ad0a02bf82a1)
