### PR TITLE
Added event labels and updates to sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "life_event_logger",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "private": true,
     "dependencies": {
         "@apollo/client": "^3.6.4",

--- a/src/components/EventLabels/EventLabelList.tsx
+++ b/src/components/EventLabels/EventLabelList.tsx
@@ -1,0 +1,122 @@
+import AddIcon from '@mui/icons-material/Add';
+import CancelIcon from '@mui/icons-material/Cancel';
+import CheckIcon from '@mui/icons-material/Check';
+import LabelIcon from '@mui/icons-material/Label';
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
+import { useState } from 'react';
+
+import { useLoggableEventsContext } from '../../providers/LoggableEventsProvider';
+import { EventLabelColor } from '../../providers/LoggableEventsProvider';
+
+export const MAX_LABEL_LENGTH = 24;
+
+const EventLabelList = () => {
+    const { eventLabels, createEventLabel } = useLoggableEventsContext();
+    const [newLabelFormIsShowing, setNewLabelFormIsShowing] = useState(false);
+    const [newLabelAlias, setNewLabelAlias] = useState('');
+
+    const aliasExists = eventLabels.some(
+        (label) => label.alias.trim().toLowerCase() === newLabelAlias.trim().toLowerCase()
+    );
+
+    const handleCreateLabel = async () => {
+        if (newLabelAlias.trim() && newLabelAlias.length <= MAX_LABEL_LENGTH && !aliasExists) {
+            await createEventLabel(newLabelAlias.trim(), EventLabelColor.Blue);
+            setNewLabelAlias('');
+            setNewLabelFormIsShowing(false);
+        }
+    };
+
+    const handleCancelCreate = () => {
+        setNewLabelAlias('');
+        setNewLabelFormIsShowing(false);
+    };
+
+    const isTooLong = newLabelAlias.length > MAX_LABEL_LENGTH;
+    const isDuplicate = !!newLabelAlias && aliasExists;
+    const isEmpty = newLabelAlias.trim() === '';
+
+    return (
+        <Box>
+            <List disablePadding>
+                <ListItem disablePadding>
+                    {newLabelFormIsShowing ? (
+                        <Box sx={{ display: 'flex', alignItems: 'flex-start', width: '90%' }}>
+                            <IconButton
+                                onClick={handleCancelCreate}
+                                size="small"
+                                color="default"
+                                sx={{ ml: 1.25, mr: 1, mt: 0.5 }}
+                                aria-label="Cancel label creation"
+                            >
+                                <CancelIcon />
+                            </IconButton>
+                            <Box sx={{ flex: 1, mr: 1 }}>
+                                <TextField
+                                    size="small"
+                                    variant="outlined"
+                                    value={newLabelAlias}
+                                    onChange={(e) => setNewLabelAlias(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') handleCreateLabel();
+                                        if (e.key === 'Escape') handleCancelCreate();
+                                    }}
+                                    autoFocus
+                                    placeholder="Label name"
+                                    fullWidth
+                                    error={isTooLong || isDuplicate}
+                                    helperText={
+                                        isTooLong
+                                            ? `Max ${MAX_LABEL_LENGTH} characters`
+                                            : isDuplicate
+                                              ? 'Label already exists'
+                                              : ''
+                                    }
+                                />
+                            </Box>
+                            <IconButton
+                                onClick={handleCreateLabel}
+                                size="small"
+                                color="primary"
+                                disabled={isTooLong || isDuplicate || isEmpty}
+                                sx={{ mt: 0.5 }}
+                                aria-label="Create label"
+                            >
+                                <CheckIcon />
+                            </IconButton>
+                        </Box>
+                    ) : (
+                        <ListItemButton dense disableRipple onClick={() => setNewLabelFormIsShowing(true)}>
+                            <ListItemIcon>
+                                <AddIcon />
+                            </ListItemIcon>
+                            <ListItemText primary="Create new label" />
+                        </ListItemButton>
+                    )}
+                </ListItem>
+
+                {eventLabels.map(({ id, alias }) => {
+                    return (
+                        <ListItem disablePadding key={id}>
+                            <ListItemButton dense disableRipple>
+                                <ListItemIcon>
+                                    <LabelIcon />
+                                </ListItemIcon>
+                                <ListItemText id={id}>{alias}</ListItemText>
+                            </ListItemButton>
+                        </ListItem>
+                    );
+                })}
+            </List>
+        </Box>
+    );
+};
+
+export default EventLabelList;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,11 +10,12 @@ import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrow
 import { useComponentDisplayContext, AppTheme } from '../providers/ComponentDisplayProvider';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
+import GitHubIcon from '@mui/icons-material/GitHub';
 
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 
-import LoggableEventList from './LoggableEventList';
+import EventLabelList from './EventLabels/EventLabelList';
 
 type Props = {
     isCollapsed: boolean;
@@ -47,6 +48,7 @@ const Sidebar = ({ isCollapsed, onCollapseSidebarClick, isOfflineMode }: Props) 
                     position: relative;
                     display: flex;
                     flex-direction: column;
+                    overflow: hidden;
                 `}
             >
                 <Collapse in={!isCollapsed} orientation="horizontal">
@@ -61,7 +63,7 @@ const Sidebar = ({ isCollapsed, onCollapseSidebarClick, isOfflineMode }: Props) 
                                 onClick={onCollapseSidebarClick}
                                 css={css`
                                     :hover {
-                                        background-color: ${teal[100]};
+                                        background-color: ${isDark ? blueGrey[600] : teal[100]};
                                     }
                                 `}
                             >
@@ -70,12 +72,26 @@ const Sidebar = ({ isCollapsed, onCollapseSidebarClick, isOfflineMode }: Props) 
                         </Tooltip>
                     </Box>
 
-                    <Box>
-                        <Typography noWrap variant="h6" gutterBottom>
+                    <Box
+                        css={css`
+                            flex: 1 1 auto;
+                            overflow-y: auto;
+                            min-height: 0;
+                        `}
+                    >
+                        <Typography noWrap variant="h5" gutterBottom>
                             Event Log {isOfflineMode && '(Offline mode)'}
                         </Typography>
 
-                        <LoggableEventList />
+                        <Box
+                            sx={{ mt: 4 }}
+                            css={css`
+                                max-height: 80vh;
+                                overflow-y: auto;
+                            `}
+                        >
+                            <EventLabelList />
+                        </Box>
                     </Box>
                 </Collapse>
                 <Box
@@ -91,6 +107,18 @@ const Sidebar = ({ isCollapsed, onCollapseSidebarClick, isOfflineMode }: Props) 
                     <Tooltip title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
                         <IconButton onClick={handleToggleTheme} color="inherit">
                             {isDark ? <Brightness7Icon /> : <Brightness4Icon />}
+                        </IconButton>
+                    </Tooltip>
+                    <Tooltip title="View on GitHub">
+                        <IconButton
+                            color="inherit"
+                            component="a"
+                            href="https://github.com/nathanchica/life_event_logger"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            sx={{ ml: 1 }}
+                        >
+                            <GitHubIcon />
                         </IconButton>
                     </Tooltip>
                 </Box>

--- a/src/providers/LoggableEventsProvider.tsx
+++ b/src/providers/LoggableEventsProvider.tsx
@@ -6,13 +6,24 @@ import { useComponentDisplayContext } from './ComponentDisplayProvider';
 import useLoggableEventsApi from '../utils/useLoggableEventsApi';
 import { sortDateObjectsByNewestFirst } from '../utils/time';
 
+export enum EventLabelColor {
+    Red = 'red',
+    Orange = 'orange',
+    Yellow = 'yellow',
+    Green = 'green',
+    Blue = 'blue',
+    Purple = 'purple',
+    Pink = 'pink',
+    Grey = 'grey'
+}
+
 interface EventLabel {
     /** id of the event label */
     id: string;
     /** Displayable alias of the event label */
     alias: string;
-    /** Color alias of the event label. The alias will map to a color that the label will be displayed with. */
-    colorAlias: string;
+    /** Color of the event label */
+    color: EventLabelColor;
 }
 
 interface LoggableEvent {
@@ -72,11 +83,11 @@ type LoggableEventsContextType = {
     /**
      * Creates an event label.
      */
-    createEventLabel: (alias: string, colorAlias: string) => void;
+    createEventLabel: (alias: string, color: EventLabelColor) => void;
     /**
      * Update details of an event label.
      */
-    updateEventLabel: (eventLabelId: string, alias: string, colorAlias: string) => void;
+    updateEventLabel: (updatedEventLabel: EventLabel) => void;
     /**
      * Delete an event label.
      */
@@ -144,11 +155,11 @@ const LoggableEventsProvider = ({ offlineMode, children }: Props) => {
                 )
             );
             setEventLabels(
-                fetchedEventLabels.map(({ id: eventLabelId, alias, colorAlias }: any) => {
+                fetchedEventLabels.map(({ id: eventLabelId, alias, color }: any) => {
                     return {
                         id: eventLabelId,
                         alias,
-                        colorAlias
+                        color
                     };
                 })
             );
@@ -230,37 +241,36 @@ const LoggableEventsProvider = ({ offlineMode, children }: Props) => {
         setLoggableEvents((prevData) => prevData.filter(({ id }) => id !== eventIdToRemove));
     };
 
-    const createEventLabel = async (alias: string, colorAlias: string) => {
-        const response = await submitCreateEventLabel(alias, colorAlias);
+    const createEventLabel = async (alias: string, color: EventLabelColor) => {
+        const response = await submitCreateEventLabel(alias, color);
 
         setEventLabels((prevData) => {
             return [
-                ...prevData,
                 {
                     id: response?.data?.createEventLabel?.id || uuidv4(),
                     alias,
-                    colorAlias
-                }
+                    color
+                },
+                ...prevData
             ];
         });
     };
 
-    const updateEventLabel = async (eventLabelId: string, alias: string, colorAlias: string) => {
+    const updateEventLabel = async (updatedEventLabel: EventLabel) => {
         setEventLabels((prevData) =>
             prevData.map((eventLabelData) => {
-                if (eventLabelData.id !== eventLabelId) {
+                if (eventLabelData.id !== updatedEventLabel.id) {
                     return eventLabelData;
                 }
 
                 return {
                     ...eventLabelData,
-                    alias,
-                    colorAlias
+                    ...updatedEventLabel
                 };
             })
         );
 
-        await submitUpdateEventLabel(eventLabelId, alias, colorAlias);
+        await submitUpdateEventLabel(updatedEventLabel.id, updatedEventLabel.alias, updatedEventLabel.color);
     };
 
     const deleteEventLabel = async (eventLabelIdToRemove: string) => {

--- a/src/tests/App.test.js
+++ b/src/tests/App.test.js
@@ -51,23 +51,10 @@ it('handles loggable event creation', async () => {
 
     expect(await screen.findByLabelText('Add event')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'get haircut' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Registered events' })).not.toBeInTheDocument();
 
     await registerLoggableEvent();
 
     expect(await screen.findByRole('heading', { name: 'get haircut' })).toBeInTheDocument();
-    expect(await screen.findByRole('heading', { name: 'Registered events' })).toBeInTheDocument();
-});
-
-it('handles disabling loggable event', async () => {
-    customRender(<App />);
-    await registerLoggableEvent();
-
-    expect(await screen.findByRole('heading', { name: 'get haircut' })).toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole('button', { name: 'get haircut' }));
-
-    expect(screen.queryByRole('heading', { name: 'get haircut' })).not.toBeInTheDocument();
 });
 
 it('handles logging an event', async () => {

--- a/src/tests/EventLabelList.test.js
+++ b/src/tests/EventLabelList.test.js
@@ -1,0 +1,113 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EventLabelList, { MAX_LABEL_LENGTH } from '../components/EventLabels/EventLabelList';
+
+// Mock context provider for LoggableEventsProvider
+const mockCreateEventLabel = jest.fn();
+const mockEventLabels = [
+    { id: '1', alias: 'Work' },
+    { id: '2', alias: 'Personal' }
+];
+
+jest.mock('../providers/LoggableEventsProvider', () => {
+    const actual = jest.requireActual('../providers/LoggableEventsProvider');
+    return {
+        ...actual,
+        useLoggableEventsContext: () => ({
+            eventLabels: mockEventLabels,
+            createEventLabel: mockCreateEventLabel
+        }),
+        EventLabelColor: { Blue: 'blue' }
+    };
+});
+
+describe('EventLabelList', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders existing labels', () => {
+        render(<EventLabelList />);
+        expect(screen.getByText('Work')).toBeInTheDocument();
+        expect(screen.getByText('Personal')).toBeInTheDocument();
+    });
+
+    it('shows the label creation form when clicking create new label', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        expect(screen.getByPlaceholderText('Label name')).toBeInTheDocument();
+    });
+
+    it('disables check button if alias is empty', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        const checkButton = screen.getByRole('button', { name: /Create label/i });
+        expect(checkButton).toBeDisabled();
+    });
+
+    it('shows error and disables check button for duplicate alias', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        const input = screen.getByPlaceholderText('Label name');
+        await userEvent.type(input, 'Work');
+        expect(screen.getByText('Label already exists')).toBeInTheDocument();
+        const checkButton = screen.getByRole('button', { name: /Create label/i });
+        expect(checkButton).toBeDisabled();
+    });
+
+    it('shows error and disables create for too long alias', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        const input = screen.getByPlaceholderText('Label name');
+        await userEvent.type(input, 'a'.repeat(MAX_LABEL_LENGTH + 1));
+        expect(screen.getByText(`Max ${MAX_LABEL_LENGTH} characters`)).toBeInTheDocument();
+        const checkButton = screen.getByRole('button', { name: /Create label/i });
+        expect(checkButton).toBeDisabled();
+    });
+
+    it('calls createEventLabel with correct value', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        const input = screen.getByPlaceholderText('Label name');
+        await userEvent.type(input, 'NewLabel');
+        const checkButton = screen.getByRole('button', { name: /Create label/i });
+        await userEvent.click(checkButton);
+        expect(mockCreateEventLabel).toHaveBeenCalledWith('NewLabel', 'blue');
+    });
+
+    it('cancels label creation on cancel button', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        expect(screen.getByPlaceholderText('Label name')).toBeInTheDocument();
+        const cancelButton = screen.getByRole('button', { name: /Cancel label creation/ });
+        await userEvent.click(cancelButton);
+        expect(screen.queryByPlaceholderText('Label name')).not.toBeInTheDocument();
+    });
+
+    it('cancels label creation on escape key', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        const input = screen.getByPlaceholderText('Label name');
+        await userEvent.type(input, '{Escape}');
+        expect(screen.queryByPlaceholderText('Label name')).not.toBeInTheDocument();
+    });
+
+    it('creates a label when pressing Enter in the input', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        const input = screen.getByPlaceholderText('Label name');
+        await userEvent.type(input, 'EnterLabel{Enter}');
+        expect(mockCreateEventLabel).toHaveBeenCalledWith('EnterLabel', 'blue');
+        await waitForElementToBeRemoved(() => screen.queryByPlaceholderText('Label name'));
+    });
+
+    it('does not create a label when pressing Enter on an empty form', async () => {
+        render(<EventLabelList />);
+        await userEvent.click(screen.getByText('Create new label'));
+        const input = screen.getByPlaceholderText('Label name');
+        await userEvent.type(input, '{Enter}');
+        expect(mockCreateEventLabel).not.toHaveBeenCalled();
+        // The input should still be present
+        expect(screen.getByPlaceholderText('Label name')).toBeInTheDocument();
+    });
+});

--- a/src/utils/useLoggableEventsApi.tsx
+++ b/src/utils/useLoggableEventsApi.tsx
@@ -11,13 +11,13 @@ export const GET_USERS_EVENTS_AND_LABELS_QUERY = gql`
                 warningThresholdInDays
                 labels {
                     alias
-                    colorAlias
+                    color
                 }
             }
             eventLabels {
                 id
                 alias
-                colorAlias
+                color
             }
         }
     }
@@ -162,10 +162,10 @@ const useLoggableEventsApi = (offlineMode: boolean) => {
     const [createEventLabelMutation] = useMutation(CREATE_EVENT_LABEL_MUTATION, mutationOptions);
     const submitCreateEventLabel = offlineMode
         ? () => Promise.resolve({ data: { createEventLabel: { id: null } } })
-        : (alias: string, colorAlias: string) => {
+        : (alias: string, color: string) => {
               return createEventLabelMutation({
                   variables: {
-                      input: { alias, colorAlias }
+                      input: { alias, color }
                   }
               });
           };
@@ -173,13 +173,13 @@ const useLoggableEventsApi = (offlineMode: boolean) => {
     const [updateEventLabelMutation] = useMutation(UPDATE_EVENT_LABEL_MUTATION, mutationOptions);
     const submitUpdateEventLabel = offlineMode
         ? () => Promise.resolve({ data: { updateEventLabel: { id: null } } })
-        : (eventLabelId: string, alias: string, colorAlias: string) => {
+        : (eventLabelId: string, alias: string, color: string) => {
               return updateEventLabelMutation({
                   variables: {
                       input: {
                           id: eventLabelId,
                           alias,
-                          colorAlias
+                          color
                       }
                   }
               });


### PR DESCRIPTION
- Updated sidebar to contain event labels and be able to create new event labels. Labeling events will be in a future PR
- Added github link to sidebar
- renamed `colorAlias` to just `color` in event labels

![image](https://github.com/user-attachments/assets/9473ac35-6bc1-4f0b-879b-e177b4601312)
