### PR TITLE
Events can now have labels

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,14 @@ module.exports = {
         'plugin:@typescript-eslint/recommended',
         'plugin:jest/recommended'
     ],
+    overrides: [
+        {
+            files: ["**/*.test.js", "**/*.test.jsx", "**/*.test.ts", "**/*.test.tsx"],
+            rules: {
+                "react/prop-types": "off"
+            }
+        }
+    ],
     parser: '@typescript-eslint/parser',
     plugins: ['react', '@typescript-eslint'],
     rules: {

--- a/src/components/EventCards/EventLabelAutocomplete.tsx
+++ b/src/components/EventCards/EventLabelAutocomplete.tsx
@@ -1,0 +1,79 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import Chip from '@mui/material/Chip';
+import TextField from '@mui/material/TextField';
+
+import { validateEventLabelName, MAX_LABEL_LENGTH } from '../../utils/validation';
+import { useLoggableEventsContext, EventLabel } from '../../providers/LoggableEventsProvider';
+
+type Props = {
+    selectedLabels: EventLabel[];
+    setSelectedLabels: React.Dispatch<React.SetStateAction<EventLabel[]>>;
+};
+
+const EventLabelAutocomplete = ({ selectedLabels, setSelectedLabels }: Props) => {
+    const { eventLabels, createEventLabel } = useLoggableEventsContext();
+    const labelOptions = eventLabels.filter((label) => !selectedLabels.some(({ id }) => id === label.id));
+
+    return (
+        <Autocomplete
+            multiple
+            freeSolo
+            options={labelOptions.map(({ name }) => name)}
+            value={selectedLabels.map(({ name }) => name)}
+            onChange={(_, values, reason) => {
+                setSelectedLabels((prevLabels: EventLabel[]) => {
+                    let newLabel: EventLabel | undefined;
+                    values.forEach((val: string) => {
+                        // Skip if the label already exists in the selected labels
+                        if (prevLabels.some((label: EventLabel) => label.name === val)) return;
+                        // Create new label if it doesn't exist
+                        if (reason === 'createOption' && !eventLabels.some((label) => label.name === val)) {
+                            const validationError = validateEventLabelName(val, eventLabels);
+                            if (validationError === null) {
+                                newLabel = createEventLabel(val);
+                            }
+                        } else {
+                            newLabel = eventLabels.find((label: EventLabel) => label.name === val);
+                        }
+                    });
+                    const filteredLabels = prevLabels.filter((label: EventLabel) => values.includes(label.name));
+                    return [...filteredLabels, ...(newLabel ? [newLabel] : [])];
+                });
+            }}
+            renderTags={(value, getTagProps) =>
+                value.map((option, index) => {
+                    const { id, name } = eventLabels.find(({ name }) => name === option) as EventLabel;
+                    return <Chip label={name} size="small" {...getTagProps({ index })} key={id} />;
+                })
+            }
+            renderInput={(params) => {
+                const inputValue = (params.inputProps as any).value || '';
+                let error = false;
+                let helperText = '';
+                if (inputValue) {
+                    const validationError = validateEventLabelName(inputValue, eventLabels);
+                    if (validationError === 'TooLongName') {
+                        error = true;
+                        helperText = `Max ${MAX_LABEL_LENGTH} characters`;
+                    }
+                }
+                return (
+                    <TextField
+                        {...params}
+                        variant="standard"
+                        label="Labels"
+                        placeholder="Type to search or create labels"
+                        autoFocus
+                        error={error}
+                        helperText={helperText}
+                    />
+                );
+            }}
+            sx={{ mt: 2, mb: 1 }}
+            disableCloseOnSelect
+            blurOnSelect
+        />
+    );
+};
+
+export default EventLabelAutocomplete;

--- a/src/components/EventCards/LoggableEventCard.tsx
+++ b/src/components/EventCards/LoggableEventCard.tsx
@@ -19,6 +19,7 @@ import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
+import Chip from '@mui/material/Chip';
 
 import blue from '@mui/material/colors/blue';
 import red from '@mui/material/colors/red';
@@ -158,12 +159,14 @@ const LoggableEventCard = ({ eventId }: Props) => {
         setDatepickerInputValue(undefined);
     };
 
-    const { loggableEvents, addTimestampToEvent, removeLoggableEvent } = useLoggableEventsContext();
+    const { loggableEvents, addTimestampToEvent, removeLoggableEvent, eventLabels } = useLoggableEventsContext();
     const currentLoggableEvent = loggableEvents.find(({ id }) => id === eventId);
 
     invariant(currentLoggableEvent, 'Must be a valid loggable event');
 
-    const { id, name, timestamps, warningThresholdInDays } = currentLoggableEvent;
+    const { id, name, timestamps, warningThresholdInDays, labelIds } = currentLoggableEvent;
+    const eventLabelObjects = labelIds && eventLabels ? eventLabels.filter(({ id }) => labelIds.includes(id)) : [];
+
     const currDate = new Date();
 
     const handleLogEventClick = async (dateToAdd?: Date | null) => {
@@ -310,6 +313,15 @@ const LoggableEventCard = ({ eventId }: Props) => {
                         />
                     ))}
                 </List>
+
+                {/* Event labels */}
+                {eventLabelObjects.length > 0 && (
+                    <Box mt={1} display="flex" flexWrap="wrap" gap={1}>
+                        {eventLabelObjects.map(({ id, name }) => (
+                            <Chip key={id} label={name} size="small" />
+                        ))}
+                    </Box>
+                )}
             </CardContent>
         </EventCard>
     );

--- a/src/components/EventCards/LoggableEventCard.tsx
+++ b/src/components/EventCards/LoggableEventCard.tsx
@@ -21,8 +21,9 @@ import Typography from '@mui/material/Typography';
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker';
 
 import blue from '@mui/material/colors/blue';
-import grey from '@mui/material/colors/grey';
 import red from '@mui/material/colors/red';
+import orange from '@mui/material/colors/orange';
+import { useTheme } from '@mui/material/styles';
 
 import CancelIcon from '@mui/icons-material/Cancel';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -50,6 +51,10 @@ const DaysSinceLastEventDisplay = ({
 }) => {
     const isViolatingThreshold = warningThresholdInDays > 0 && daysSinceLastEvent >= warningThresholdInDays;
 
+    // Detect dark mode using MUI's useTheme
+    const theme = useTheme();
+    const isDarkMode = theme.palette.mode === 'dark';
+
     let textToDisplay = `Last event: ${daysSinceLastEvent} days ago`;
     if (daysSinceLastEvent === 0) {
         textToDisplay = `Last event: Today`;
@@ -57,16 +62,19 @@ const DaysSinceLastEventDisplay = ({
         textToDisplay = `Last event: Yesterday`;
     }
 
+    // Use orange[500] in dark mode, red[500] otherwise
+    const warningColor = isDarkMode ? orange[500] : red[500];
+
     return (
         <Box
             css={css`
                 margin-top: 8px;
-                color: ${isViolatingThreshold ? red[500] : 'inherit'};
+                color: ${isViolatingThreshold ? warningColor : 'inherit'};
             `}
         >
             <Stack direction="row" spacing={1}>
                 <Typography variant="caption">{textToDisplay}</Typography>
-                {isViolatingThreshold && <WarningAmberIcon color="error" fontSize="small" />}
+                {isViolatingThreshold && <WarningAmberIcon style={{ color: warningColor }} fontSize="small" />}
             </Stack>
         </Box>
     );

--- a/src/components/EventLabels/EventLabel.tsx
+++ b/src/components/EventLabels/EventLabel.tsx
@@ -113,7 +113,7 @@ const EventLabel = ({ data, isShowingEditActions }: Props) => {
                             validationError === 'TooLongName'
                                 ? `Max ${MAX_LABEL_LENGTH} characters`
                                 : validationError === 'EmptyName'
-                                  ? 'Label cannot be empty'
+                                  ? 'Cannot be empty'
                                   : validationError === 'DuplicateName'
                                     ? 'Label already exists'
                                     : ''

--- a/src/components/EventLoggerPage.tsx
+++ b/src/components/EventLoggerPage.tsx
@@ -15,6 +15,9 @@ type Props = {
  *
  * This component serves as the main entry point for the event logger application, managing which view to display
  * based on the user's login status and whether the application is in offline mode.
+ *
+ * It uses Material-UI's ThemeProvider to apply a theme based on the current mode (light or dark).
+ * The theme includes custom styles for error states in form components when in dark mode.
  */
 const EventLoggerPage = ({ isOfflineMode, isLoggedIn }: Props) => {
     const { theme: mode } = useComponentDisplayContext();
@@ -24,7 +27,54 @@ const EventLoggerPage = ({ isOfflineMode, isLoggedIn }: Props) => {
             createTheme({
                 palette: {
                     mode
-                }
+                },
+                components:
+                    mode === 'dark'
+                        ? {
+                              MuiFormHelperText: {
+                                  styleOverrides: {
+                                      root: {
+                                          '&.Mui-error': {
+                                              color: 'orange'
+                                          }
+                                      }
+                                  }
+                              },
+                              MuiInputLabel: {
+                                  styleOverrides: {
+                                      root: {
+                                          '&.Mui-error': {
+                                              color: 'orange'
+                                          }
+                                      }
+                                  }
+                              },
+                              MuiOutlinedInput: {
+                                  styleOverrides: {
+                                      notchedOutline: {
+                                          // This targets the outline border color for error state
+                                          '&.Mui-error': {
+                                              borderColor: 'orange'
+                                          }
+                                      },
+                                      root: {
+                                          '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+                                              borderColor: 'orange'
+                                          }
+                                      }
+                                  }
+                              },
+                              MuiInput: {
+                                  styleOverrides: {
+                                      underline: {
+                                          '&.Mui-error:after': {
+                                              borderBottomColor: 'orange'
+                                          }
+                                      }
+                                  }
+                              }
+                          }
+                        : {}
             }),
         [mode]
     );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import Brightness7Icon from '@mui/icons-material/Brightness7';
 import EditIcon from '@mui/icons-material/Edit';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
 
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
@@ -37,106 +38,112 @@ const Sidebar = ({ isCollapsed, onCollapseSidebarClick, isOfflineMode }: Props) 
     const isDark = theme === AppTheme.Dark;
     const handleToggleTheme = () => (isDark ? enableLightTheme() : enableDarkTheme());
 
+    const handleClickAway = () => {
+        if (isEditingLabels) setIsEditingLabels(false);
+    };
+
     return (
-        <Collapse
-            in={!isCollapsed}
-            collapsedSize={56}
-            orientation="horizontal"
-            css={css`
-                height: 100%;
-            `}
-        >
-            <Paper
-                elevation={3}
-                square
+        <ClickAwayListener onClickAway={handleClickAway}>
+            <Collapse
+                in={!isCollapsed}
+                collapsedSize={56}
+                orientation="horizontal"
                 css={css`
-                    background-color: ${isDark ? blueGrey[900] : green[100]};
-                    padding: 16px;
-                    width: 400px;
                     height: 100%;
-                    position: relative;
-                    display: flex;
-                    flex-direction: column;
-                    overflow: hidden;
                 `}
             >
-                <Collapse in={!isCollapsed} orientation="horizontal">
-                    <Box
-                        css={css`
-                            position: absolute;
-                            right: 16px;
-                        `}
-                    >
-                        <Tooltip title="Hide sidebar">
-                            <IconButton
-                                onClick={onCollapseSidebarClick}
+                <Paper
+                    elevation={3}
+                    square
+                    css={css`
+                        background-color: ${isDark ? blueGrey[900] : green[100]};
+                        padding: 16px;
+                        width: 400px;
+                        height: 100%;
+                        position: relative;
+                        display: flex;
+                        flex-direction: column;
+                        overflow: hidden;
+                    `}
+                >
+                    <Collapse in={!isCollapsed} orientation="horizontal">
+                        <Box
+                            css={css`
+                                position: absolute;
+                                right: 16px;
+                            `}
+                        >
+                            <Tooltip title="Hide sidebar">
+                                <IconButton
+                                    onClick={onCollapseSidebarClick}
+                                    css={css`
+                                        :hover {
+                                            background-color: ${isDark ? blueGrey[600] : green[200]};
+                                        }
+                                    `}
+                                >
+                                    <KeyboardDoubleArrowLeftIcon />
+                                </IconButton>
+                            </Tooltip>
+                        </Box>
+
+                        <Box
+                            css={css`
+                                flex: 1 1 auto;
+                                overflow-y: auto;
+                                min-height: 0;
+                            `}
+                        >
+                            <Typography noWrap variant="h5" gutterBottom>
+                                Event Log {isOfflineMode && '(Offline mode)'}
+                            </Typography>
+
+                            <Box
+                                sx={{ mt: 4 }}
                                 css={css`
-                                    :hover {
-                                        background-color: ${isDark ? blueGrey[600] : green[200]};
-                                    }
+                                    max-height: 80vh;
+                                    overflow-y: auto;
                                 `}
                             >
-                                <KeyboardDoubleArrowLeftIcon />
+                                <EventLabelList isEditing={isEditingLabels} />
+                            </Box>
+                        </Box>
+                    </Collapse>
+                    <Box
+                        sx={{
+                            position: 'absolute',
+                            left: 8,
+                            bottom: 16,
+                            display: 'flex',
+                            justifyContent: 'flex-start',
+                            width: '100%'
+                        }}
+                    >
+                        <Tooltip title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
+                            <IconButton onClick={handleToggleTheme}>
+                                {isDark ? <Brightness7Icon /> : <Brightness4Icon />}
+                            </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Manage labels">
+                            <IconButton onClick={() => setIsEditingLabels((prev) => !prev)} sx={{ ml: 1 }}>
+                                <EditIcon />
+                            </IconButton>
+                        </Tooltip>
+                        <Tooltip title="View on GitHub">
+                            <IconButton
+                                component="a"
+                                href="https://github.com/nathanchica/life_event_logger"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                sx={{ ml: 1 }}
+                            >
+                                <GitHubIcon />
                             </IconButton>
                         </Tooltip>
                     </Box>
-
-                    <Box
-                        css={css`
-                            flex: 1 1 auto;
-                            overflow-y: auto;
-                            min-height: 0;
-                        `}
-                    >
-                        <Typography noWrap variant="h5" gutterBottom>
-                            Event Log {isOfflineMode && '(Offline mode)'}
-                        </Typography>
-
-                        <Box
-                            sx={{ mt: 4 }}
-                            css={css`
-                                max-height: 80vh;
-                                overflow-y: auto;
-                            `}
-                        >
-                            <EventLabelList isEditing={isEditingLabels} />
-                        </Box>
-                    </Box>
-                </Collapse>
-                <Box
-                    sx={{
-                        position: 'absolute',
-                        left: 8,
-                        bottom: 16,
-                        display: 'flex',
-                        justifyContent: 'flex-start',
-                        width: '100%'
-                    }}
-                >
-                    <Tooltip title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
-                        <IconButton onClick={handleToggleTheme}>
-                            {isDark ? <Brightness7Icon /> : <Brightness4Icon />}
-                        </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Manage labels">
-                        <IconButton onClick={() => setIsEditingLabels((prev) => !prev)} sx={{ ml: 1 }}>
-                            <EditIcon />
-                        </IconButton>
-                    </Tooltip>
-                    <Tooltip title="View on GitHub">
-                        <IconButton
-                            component="a"
-                            href="https://github.com/nathanchica/life_event_logger"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            sx={{ ml: 1 }}
-                        >
-                            <GitHubIcon />
-                        </IconButton>
-                    </Tooltip>
-                </Box>
-            </Paper>
-        </Collapse>
+                </Paper>
+            </Collapse>
+        </ClickAwayListener>
     );
 };
 

--- a/src/providers/ComponentDisplayProvider.tsx
+++ b/src/providers/ComponentDisplayProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, ReactNode } from 'react';
 import invariant from 'tiny-invariant';
+import useMediaQuery from '@mui/material/useMediaQuery';
 
 export enum AppTheme {
     Light = 'light',
@@ -36,6 +37,12 @@ type Props = {
  * It provides methods to show/hide the login view, loading state, and to switch between light and dark themes.
  */
 const ComponentDisplayProvider = ({ offlineMode, children }: Props) => {
+    // Detect OS preference for dark mode
+    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+    const [theme, setTheme] = useState<AppTheme>(prefersDarkMode ? AppTheme.Dark : AppTheme.Light);
+    const enableLightTheme = () => setTheme(AppTheme.Light);
+    const enableDarkTheme = () => setTheme(AppTheme.Dark);
+
     const [loginViewIsShowing, setLoginViewIsShowing] = useState(true);
     const showLoginView = () => setLoginViewIsShowing(true);
     const hideLoginView = () => setLoginViewIsShowing(false);
@@ -43,10 +50,6 @@ const ComponentDisplayProvider = ({ offlineMode, children }: Props) => {
     const [loadingStateIsShowing, setLoadingStateIsShowing] = useState(!offlineMode);
     const showLoadingState = () => setLoadingStateIsShowing(true);
     const hideLoadingState = () => setLoadingStateIsShowing(false);
-
-    const [theme, setTheme] = useState<AppTheme>(AppTheme.Light);
-    const enableLightTheme = () => setTheme(AppTheme.Light);
-    const enableDarkTheme = () => setTheme(AppTheme.Dark);
 
     const contextValue = {
         showLoginView,

--- a/src/tests/EventLabelAutocomplete.test.js
+++ b/src/tests/EventLabelAutocomplete.test.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import EventLabelAutocomplete from '../components/EventCards/EventLabelAutocomplete';
+import { MAX_LABEL_LENGTH } from '../utils/validation';
+
+const mockEventLabels = [
+    { id: '1', name: 'Work' },
+    { id: '2', name: 'Personal' },
+    { id: '3', name: 'Fitness' }
+];
+
+const mockCreateEventLabel = jest.fn((name) => ({ id: Math.random().toString(), name }));
+
+// Mock context hook for LoggableEventsProvider
+jest.mock('../providers/LoggableEventsProvider', () => {
+    const actual = jest.requireActual('../providers/LoggableEventsProvider');
+    return {
+        ...actual,
+        useLoggableEventsContext: () => ({
+            eventLabels: mockEventLabels,
+            createEventLabel: mockCreateEventLabel
+        })
+    };
+});
+
+function TestEventLabelAutocomplete({ initialSelectedLabels = [] }) {
+    const [selectedLabels, setSelectedLabels] = React.useState(initialSelectedLabels);
+    return <EventLabelAutocomplete selectedLabels={selectedLabels} setSelectedLabels={setSelectedLabels} />;
+}
+
+describe('EventLabelAutocomplete', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders label chips for selected labels', () => {
+        render(<TestEventLabelAutocomplete initialSelectedLabels={[mockEventLabels[0], mockEventLabels[1]]} />);
+        expect(screen.getByText('Work')).toBeInTheDocument();
+        expect(screen.getByText('Personal')).toBeInTheDocument();
+    });
+
+    it('shows suggestions when typing', async () => {
+        render(<TestEventLabelAutocomplete initialSelectedLabels={[]} />);
+        const input = screen.getByLabelText('Labels');
+        await userEvent.type(input, 'F');
+        expect(await screen.findByText('Fitness')).toBeInTheDocument();
+    });
+
+    it('calls createEventLabel for new label', async () => {
+        mockCreateEventLabel.mockClear();
+        render(<TestEventLabelAutocomplete initialSelectedLabels={[]} />);
+        const input = screen.getByLabelText('Labels');
+        await userEvent.type(input, 'NewLabel');
+        await userEvent.keyboard('{Enter}');
+        await waitFor(() => {
+            expect(mockCreateEventLabel).toHaveBeenCalledWith('NewLabel');
+        });
+    });
+
+    it('selects a suggestion from the autocomplete', async () => {
+        render(<TestEventLabelAutocomplete initialSelectedLabels={[]} />);
+        const input = screen.getByLabelText('Labels');
+        await userEvent.type(input, 'Fit');
+        const suggestion = await screen.findByText('Fitness');
+        await userEvent.click(suggestion);
+        expect(screen.getByText('Fitness')).toBeInTheDocument();
+    });
+
+    it('shows error when label name is too long', async () => {
+        render(<TestEventLabelAutocomplete initialSelectedLabels={[]} />);
+        const input = screen.getByLabelText('Labels');
+        const longLabel = 'A'.repeat(MAX_LABEL_LENGTH + 1);
+        await userEvent.type(input, longLabel);
+        expect(await screen.findByText(`Max ${MAX_LABEL_LENGTH} characters`)).toBeInTheDocument();
+    });
+
+    it('does not add a label that is already selected when pressing enter', async () => {
+        render(<TestEventLabelAutocomplete initialSelectedLabels={[mockEventLabels[0]]} />);
+        const input = screen.getByLabelText('Labels');
+        await userEvent.type(input, 'Work');
+        await userEvent.keyboard('{Enter}');
+        // The 'Work' label should only appear once in the document
+        expect(screen.getAllByText('Work').length).toBe(1);
+    });
+
+    it('does not add a label with invalid name when pressing enter', async () => {
+        render(<TestEventLabelAutocomplete initialSelectedLabels={[]} />);
+        const input = screen.getByLabelText('Labels');
+        // Use a name that is too long
+        const invalidLabel = 'A'.repeat(MAX_LABEL_LENGTH + 1);
+        await userEvent.type(input, invalidLabel);
+        // Error message should be shown
+        expect(await screen.findByText(`Max ${MAX_LABEL_LENGTH} characters`)).toBeInTheDocument();
+        await userEvent.keyboard('{Enter}');
+        // The invalid label should not be present as a chip or option
+        expect(screen.queryByText(invalidLabel)).not.toBeInTheDocument();
+    });
+
+    it('skips adding already selected labels when multiple are selected', async () => {
+        // Start with 'Work' selected, then try to select 'Work' and 'Personal' together
+        render(<TestEventLabelAutocomplete initialSelectedLabels={[mockEventLabels[0]]} />);
+        const input = screen.getByLabelText('Labels');
+        // Simulate typing 'Personal' and selecting it
+        await userEvent.type(input, 'Personal');
+        const suggestion = await screen.findByText('Personal');
+        await userEvent.click(suggestion);
+        // Now try to type 'Work' again and press enter
+        await userEvent.type(input, 'Work');
+        await userEvent.keyboard('{Enter}');
+        // Only one 'Work' chip should be present, and 'Personal' should be present
+        expect(screen.getAllByText('Work').length).toBe(1);
+        expect(screen.getByText('Personal')).toBeInTheDocument();
+    });
+});

--- a/src/tests/EventLabelList.test.js
+++ b/src/tests/EventLabelList.test.js
@@ -78,7 +78,7 @@ describe('EventLabelList', () => {
         const input = screen.getByPlaceholderText('Label name');
         await userEvent.type(input, 'EnterLabel{Enter}');
         expect(await screen.findByText('EnterLabel')).toBeInTheDocument();
-        expect(screen.queryByPlaceholderText('Label name')).not.toBeInTheDocument();
+        await waitForElementToBeRemoved(() => screen.queryByPlaceholderText('Label name'));
     });
 
     it('does not create a label when pressing Enter on an empty form', async () => {


### PR DESCRIPTION
- new form in event edit card to let user select labels for the event being edited
- user can also create new events from that label select form
- labels for an event now displayed in that event's card
- error text colors in dark mode are now in orange
- removed eslint's react/prop-types check from test files
- app now respects user's system's preference for light mode or dark mode

![image](https://github.com/user-attachments/assets/728ed578-4ed1-4047-be94-1dcb503dc878)
![image](https://github.com/user-attachments/assets/8ba5856a-6c3c-4b79-a996-23e17f475008)
