### PR TITLE
Filter events by labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "life_event_logger",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "dependencies": {
         "@apollo/client": "^3.6.4",

--- a/src/components/EventCards/EditEventCard.tsx
+++ b/src/components/EventCards/EditEventCard.tsx
@@ -17,8 +17,9 @@ import { useTheme } from '@mui/material/styles';
 import { css } from '@emotion/react';
 
 import EventCard from './EventCard';
-import { useLoggableEventsContext, EventLabel, EVENT_DEFAULT_VALUES } from '../../providers/LoggableEventsProvider';
 import EventLabelAutocomplete from './EventLabelAutocomplete';
+import { useLoggableEventsContext, EventLabel, EVENT_DEFAULT_VALUES } from '../../providers/LoggableEventsProvider';
+import { useComponentDisplayContext } from '../../providers/ComponentDisplayProvider';
 
 export const MAX_LENGTH = 25;
 export const MAX_WARNING_THRESHOLD_DAYS = 365 * 2; // 2 years
@@ -55,10 +56,12 @@ const WarningSwitch = ({ checked, onChange }: { checked: boolean; onChange: (new
 const EditEventCard = ({ onDismiss, eventIdToEdit }: Props) => {
     /** Context */
     const { loggableEvents, createLoggableEvent, updateLoggableEventDetails, eventLabels } = useLoggableEventsContext();
+    const { activeEventLabelId } = useComponentDisplayContext();
 
     const theme = useTheme();
 
     const eventToEdit = loggableEvents.find(({ id }) => id === eventIdToEdit) || EVENT_DEFAULT_VALUES;
+    const isCreatingNewEvent = !eventIdToEdit;
 
     /** Event name */
     const [eventNameInputValue, setEventNameInputValue] = useState(eventToEdit.name);
@@ -100,8 +103,14 @@ const EditEventCard = ({ onDismiss, eventIdToEdit }: Props) => {
     /**
      * Labels
      */
-    const [showLabelInput, setShowLabelInput] = useState(eventToEdit.labelIds && eventToEdit.labelIds.length > 0);
+    const activeLabelObj = activeEventLabelId ? eventLabels.find((l) => l.id === activeEventLabelId) : undefined;
+    const [showLabelInput, setShowLabelInput] = useState(
+        isCreatingNewEvent ? Boolean(activeEventLabelId) : eventToEdit.labelIds && eventToEdit.labelIds.length > 0
+    );
     const [selectedLabels, setSelectedLabels] = useState<EventLabel[]>(() => {
+        if (isCreatingNewEvent && activeLabelObj) {
+            return [activeLabelObj];
+        }
         // If editing, pre-populate with existing labels
         return eventToEdit.labelIds ? eventLabels.filter(({ id }) => eventToEdit.labelIds.includes(id)) : [];
     });

--- a/src/components/EventLabels/EventLabel.tsx
+++ b/src/components/EventLabels/EventLabel.tsx
@@ -12,6 +12,7 @@ import CancelIcon from '@mui/icons-material/Cancel';
 import CheckIcon from '@mui/icons-material/Check';
 
 import { useLoggableEventsContext, EventLabel as EventLabelType } from '../../providers/LoggableEventsProvider';
+import { useComponentDisplayContext } from '../../providers/ComponentDisplayProvider';
 import { validateEventLabelName, MAX_LABEL_LENGTH } from '../../utils/validation';
 
 type Props = {
@@ -25,6 +26,10 @@ type Props = {
 const EventLabel = ({ data, isShowingEditActions }: Props) => {
     const { updateEventLabel, deleteEventLabel, eventLabels } = useLoggableEventsContext();
     const { id, name } = data;
+
+    // Add context for active label
+    const { activeEventLabelId, setActiveEventLabelId } = useComponentDisplayContext();
+    const isActive = activeEventLabelId === id;
 
     const [isEditingName, setIsEditingName] = useState(false);
     const [editValue, setEditValue] = useState(name);
@@ -59,6 +64,10 @@ const EventLabel = ({ data, isShowingEditActions }: Props) => {
         }
     };
 
+    const handleLabelClick = () => {
+        setActiveEventLabelId(isActive ? null : id);
+    };
+
     return (
         <ListItem
             disablePadding
@@ -83,7 +92,7 @@ const EventLabel = ({ data, isShowingEditActions }: Props) => {
                 ) : null
             }
         >
-            <ListItemButton dense disableRipple>
+            <ListItemButton dense disableRipple onClick={handleLabelClick} selected={isActive}>
                 <ListItemIcon>
                     {isShowingEditActions ? (
                         isEditingName ? (

--- a/src/components/LoggableEventsView.tsx
+++ b/src/components/LoggableEventsView.tsx
@@ -30,7 +30,8 @@ type Props = {
  * It includes a sidebar for navigation and a loading state while data is being fetched.
  */
 const LoggableEventsView = ({ offlineMode }: Props) => {
-    const { loadingStateIsShowing, showLoadingState, hideLoadingState } = useComponentDisplayContext();
+    const { loadingStateIsShowing, showLoadingState, hideLoadingState, activeEventLabelId } =
+        useComponentDisplayContext();
     const { loggableEvents, dataIsLoaded } = useLoggableEventsContext();
     const theme = useTheme();
 
@@ -39,6 +40,10 @@ const LoggableEventsView = ({ offlineMode }: Props) => {
     const collapseSidebar = () => setSidebarIsCollapsed(true);
 
     const isDarkMode = theme.palette.mode === AppTheme.Dark;
+
+    const filteredEvents = activeEventLabelId
+        ? loggableEvents.filter(({ active, labelIds }) => active && labelIds && labelIds.includes(activeEventLabelId))
+        : loggableEvents.filter(({ active }) => active);
 
     const mainContent = (
         <Grid
@@ -66,15 +71,13 @@ const LoggableEventsView = ({ offlineMode }: Props) => {
                         <Grid item>
                             <CreateEventCard />
                         </Grid>
-                        {loggableEvents
-                            .filter(({ active }) => active)
-                            .map(({ id, name }) => {
-                                return (
-                                    <Grid item key={`${name}-card`}>
-                                        <LoggableEventCard eventId={id} />
-                                    </Grid>
-                                );
-                            })}
+                        {filteredEvents.map(({ id, name }) => {
+                            return (
+                                <Grid item key={`${name}-card`}>
+                                    <LoggableEventCard eventId={id} />
+                                </Grid>
+                            );
+                        })}
                     </>
                 )}
             </Grid>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -120,12 +120,19 @@ const Sidebar = ({ isCollapsed, onCollapseSidebarClick, isOfflineMode }: Props) 
                         }}
                     >
                         <Tooltip title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
-                            <IconButton onClick={handleToggleTheme}>
+                            <IconButton
+                                onClick={handleToggleTheme}
+                                aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+                            >
                                 {isDark ? <Brightness7Icon /> : <Brightness4Icon />}
                             </IconButton>
                         </Tooltip>
                         <Tooltip title="Manage labels">
-                            <IconButton onClick={() => setIsEditingLabels((prev) => !prev)} sx={{ ml: 1 }}>
+                            <IconButton
+                                onClick={() => setIsEditingLabels((prev) => !prev)}
+                                sx={{ ml: 1 }}
+                                aria-label="Manage labels"
+                            >
                                 <EditIcon />
                             </IconButton>
                         </Tooltip>
@@ -136,6 +143,7 @@ const Sidebar = ({ isCollapsed, onCollapseSidebarClick, isOfflineMode }: Props) 
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 sx={{ ml: 1 }}
+                                aria-label="View on GitHub"
                             >
                                 <GitHubIcon />
                             </IconButton>

--- a/src/providers/ComponentDisplayProvider.tsx
+++ b/src/providers/ComponentDisplayProvider.tsx
@@ -17,6 +17,8 @@ type ComponentDisplayContextType = {
     theme: AppTheme;
     enableLightTheme: () => void;
     enableDarkTheme: () => void;
+    activeEventLabelId: string | null;
+    setActiveEventLabelId: (id: string | null) => void;
 };
 
 export const ComponentDisplayContext = createContext<ComponentDisplayContextType | null>(null);
@@ -51,6 +53,8 @@ const ComponentDisplayProvider = ({ offlineMode, children }: Props) => {
     const showLoadingState = () => setLoadingStateIsShowing(true);
     const hideLoadingState = () => setLoadingStateIsShowing(false);
 
+    const [activeEventLabelId, setActiveEventLabelId] = useState<string | null>(null);
+
     const contextValue = {
         showLoginView,
         hideLoginView,
@@ -60,7 +64,9 @@ const ComponentDisplayProvider = ({ offlineMode, children }: Props) => {
         loadingStateIsShowing,
         theme,
         enableLightTheme,
-        enableDarkTheme
+        enableDarkTheme,
+        activeEventLabelId,
+        setActiveEventLabelId
     };
 
     return <ComponentDisplayContext.Provider value={contextValue}>{children}</ComponentDisplayContext.Provider>;

--- a/src/tests/App.test.js
+++ b/src/tests/App.test.js
@@ -92,3 +92,23 @@ it('handles empty event name input', async () => {
 
     expect(screen.queryByRole('heading', { name: 'get haircut' })).not.toBeInTheDocument();
 });
+
+it('toggles between light mode and dark mode', async () => {
+    customRender(<App />);
+    await registerLoggableEvent();
+
+    // Should start in light mode, so button label is 'Switch to dark mode'
+    let toggleButton = await screen.findByRole('button', { name: /switch to dark mode/i });
+    expect(toggleButton).toBeInTheDocument();
+
+    // Toggle to dark mode
+    await userEvent.click(toggleButton);
+    // Now the button label should be 'Switch to light mode'
+    toggleButton = await screen.findByRole('button', { name: /switch to light mode/i });
+    expect(toggleButton).toBeInTheDocument();
+
+    // Toggle back to light mode
+    await userEvent.click(toggleButton);
+    toggleButton = await screen.findByRole('button', { name: /switch to dark mode/i });
+    expect(toggleButton).toBeInTheDocument();
+});

--- a/src/tests/EventLabel.test.js
+++ b/src/tests/EventLabel.test.js
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import EventLabel from '../components/EventLabels/EventLabel';
 import { MAX_LABEL_LENGTH } from '../utils/validation';
+import ComponentDisplayProvider from '../providers/ComponentDisplayProvider';
 
 // Mock context hook for LoggableEventsProvider
 const mockUpdateEventLabel = jest.fn();
@@ -29,7 +30,7 @@ jest.mock('../providers/LoggableEventsProvider', () => {
 const defaultLabel = { id: '1', name: 'Work', color: 'blue' };
 
 function renderWithProvider(ui) {
-    return render(ui);
+    return render(<ComponentDisplayProvider>{ui}</ComponentDisplayProvider>);
 }
 
 describe('EventLabel', () => {

--- a/src/tests/EventLabelList.test.js
+++ b/src/tests/EventLabelList.test.js
@@ -4,13 +4,16 @@ import { MockedProvider } from '@apollo/client/testing';
 
 import EventLabelList from '../components/EventLabels/EventLabelList';
 import LoggableEventsProvider from '../providers/LoggableEventsProvider';
+import ComponentDisplayProvider from '../providers/ComponentDisplayProvider';
 import { MAX_LABEL_LENGTH } from '../utils/validation';
 
 describe('EventLabelList', () => {
     function renderWithProvider(ui) {
         return render(
             <MockedProvider mocks={[]} addTypename={false}>
-                <LoggableEventsProvider offlineMode={true}>{ui}</LoggableEventsProvider>
+                <LoggableEventsProvider offlineMode={true}>
+                    <ComponentDisplayProvider offlineMode={true}>{ui}</ComponentDisplayProvider>
+                </LoggableEventsProvider>
             </MockedProvider>
         );
     }


### PR DESCRIPTION
- can now filter events by labels in the sidebar by selecting a label
- creating a new event while a label is selected will pre-populate the labels field of that new event with the selected label

![image](https://github.com/user-attachments/assets/6bf34231-3d9d-423a-896f-e28650ea3b61)
