### PR TITLE
Update optimisitic payload for addTimestampToEvent

### DIFF
--- a/src/components/EventCards/EventCardLogActions.tsx
+++ b/src/components/EventCards/EventCardLogActions.tsx
@@ -23,16 +23,16 @@ const EventCardLogActions = ({ eventId, daysSinceLastEvent, timestamps }: Props)
     const { addTimestampToEvent, addTimestampIsLoading } = useLoggableEvents();
     const { value: datepickerIsShowing, setFalse: hideDatepicker, toggle: toggleDatepicker } = useToggle();
 
-    const handleLogEventClick = async (dateToAdd?: Date | null) => {
+    const handleLogEventClick = (dateToAdd?: Date | null) => {
         const currentDate = new Date();
-        await addTimestampToEvent({
+        addTimestampToEvent({
             eventId,
             timestamp: (dateToAdd || currentDate).toISOString()
         });
     };
 
-    const handleDatepickerAccept = async (date: Date) => {
-        await handleLogEventClick(date);
+    const handleDatepickerAccept = (date: Date) => {
+        handleLogEventClick(date);
         hideDatepicker();
     };
 

--- a/src/components/EventCards/EventRecord.tsx
+++ b/src/components/EventCards/EventRecord.tsx
@@ -29,8 +29,8 @@ const EventRecord = ({ eventId, recordDate, currentDate }: Props) => {
 
     const isFutureDate = getNumberOfDaysBetweenDates(recordDate, currentDate) < 0;
 
-    const onDeleteRecord = async () => {
-        await removeTimestampFromEvent({
+    const onDeleteRecord = () => {
+        removeTimestampFromEvent({
             eventId,
             timestamp: recordDate.toISOString()
         });

--- a/src/hooks/useLoggableEvents.ts
+++ b/src/hooks/useLoggableEvents.ts
@@ -318,7 +318,7 @@ export const useLoggableEvents = () => {
     const [addTimestampMutation, { loading: addTimestampIsLoading }] = useMutation(ADD_TIMESTAMP_TO_EVENT_MUTATION, {
         optimisticResponse: (variables) => ({
             addTimestampToEvent: {
-                __typename: 'AddTimestampPayload',
+                __typename: 'AddTimestampToEventMutationPayload',
                 loggableEvent: {
                     __typename: 'LoggableEvent',
                     id: variables.input.eventId,
@@ -394,32 +394,30 @@ export const useLoggableEvents = () => {
     /**
      * Add a timestamp to an event
      */
-    const addTimestampToEvent = async (input: AddTimestampInput): Promise<AddTimestampPayload | null> => {
+    const addTimestampToEvent = (input: AddTimestampInput): void => {
         try {
-            const result = await addTimestampMutation({
+            addTimestampMutation({
                 variables: { input }
             });
-            return result.data?.addTimestampToEvent || null;
         } catch {
             // Don't throw the error - this allows the optimistic update to persist
             // even when the network request fails
-            return null;
+            return;
         }
     };
 
     /**
      * Remove a timestamp from an event
      */
-    const removeTimestampFromEvent = async (input: RemoveTimestampInput): Promise<RemoveTimestampPayload | null> => {
+    const removeTimestampFromEvent = (input: RemoveTimestampInput): void => {
         try {
-            const result = await removeTimestampMutation({
+            removeTimestampMutation({
                 variables: { input }
             });
-            return result.data?.removeTimestampFromEvent || null;
         } catch {
             // Don't throw the error - this allows the optimistic update to persist
             // even when the network request fails
-            return null;
+            return;
         }
     };
 


### PR DESCRIPTION
This pull request refactors event logging functionality by removing unnecessary `async`/`await` usage and simplifying mutation handling. Additionally, it updates GraphQL type names for consistency. Below are the key changes:

### Refactoring to Remove `async`/`await`:

* [`src/components/EventCards/EventCardLogActions.tsx`](diffhunk://#diff-5d1f33ad772a628b0664e7edb29e0feb9a673d2b0491bead4a48410176ad1fc1L26-R35): Removed `async`/`await` from `handleLogEventClick` and `handleDatepickerAccept` functions, simplifying their implementation.
* [`src/components/EventCards/EventRecord.tsx`](diffhunk://#diff-e6cce5702178e3dd01662a9e807bc4fe0a2394bac60177b9ddcc7673b5deadb7L32-R33): Removed `async`/`await` from the `onDeleteRecord` function for streamlined mutation handling.

### Simplification of Mutation Functions:

* [`src/hooks/useLoggableEvents.ts`](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L397-R420): Refactored `addTimestampToEvent` and `removeTimestampFromEvent` functions to remove `async`/`await`, returning `void` instead of `Promise`. This ensures the optimistic updates persist even if the network request fails.

### GraphQL Type Name Update:

* [`src/hooks/useLoggableEvents.ts`](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L321-R321): Updated the GraphQL type name from `AddTimestampPayload` to `AddTimestampToEventMutationPayload` for consistency with naming conventions.