### PR TITLE
fix optimistic responses when updating events by fetching existing event

### DIFF
--- a/src/hooks/useEventLabels.ts
+++ b/src/hooks/useEventLabels.ts
@@ -189,17 +189,19 @@ export const useEventLabels = () => {
     });
 
     const [updateEventLabelMutation, { loading: updateIsLoading }] = useMutation(UPDATE_EVENT_LABEL_MUTATION, {
-        optimisticResponse: (variables) => ({
-            updateEventLabel: {
-                __typename: 'UpdateEventLabelMutationPayload',
-                eventLabel: {
-                    __typename: 'EventLabel',
-                    id: variables.input.id,
-                    name: variables.input.name
-                },
-                errors: []
-            }
-        })
+        optimisticResponse: (variables) => {
+            return {
+                updateEventLabel: {
+                    __typename: 'UpdateEventLabelMutationPayload',
+                    eventLabel: {
+                        __typename: 'EventLabel',
+                        id: variables.input.id,
+                        name: variables.input.name
+                    },
+                    errors: []
+                }
+            };
+        }
     });
 
     const [deleteEventLabelMutation, { loading: deleteIsLoading }] = useMutation(DELETE_EVENT_LABEL_MUTATION, {


### PR DESCRIPTION
This pull request refactors the optimistic response logic in two hooks, `useEventLabels` and `useLoggableEvents`, to improve data consistency by leveraging Apollo Client's cache. Additionally, it introduces the `useApolloClient` hook to access the Apollo cache and updates type imports for better type safety.

### Refactoring Optimistic Responses:

* [`src/hooks/useEventLabels.ts`](diffhunk://#diff-ff6763c21142d81a7f2964f32be8733d3c67d6aaa0132cad26fd6164574c9d36L192-R193): Updated the `optimisticResponse` function in the `updateEventLabelMutation` to use a more explicit return statement for better readability. [[1]](diffhunk://#diff-ff6763c21142d81a7f2964f32be8733d3c67d6aaa0132cad26fd6164574c9d36L192-R193) [[2]](diffhunk://#diff-ff6763c21142d81a7f2964f32be8733d3c67d6aaa0132cad26fd6164574c9d36L202-R204)

* [`src/hooks/useLoggableEvents.ts`](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L262-R284): Enhanced the `optimisticResponse` logic in the `updateLoggableEventMutation` and `addTimestampMutation` by using the Apollo cache to read existing fragments (`LoggableEventFragment`). This ensures that optimistic updates include existing data, such as timestamps and labels, when modifying or adding events. [[1]](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L262-R284) [[2]](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L319-R349)

### Apollo Client Integration:

* [`src/hooks/useLoggableEvents.ts`](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793R205): Added the `useApolloClient` hook to access the Apollo cache, enabling the retrieval of existing event data for more accurate optimistic updates.

### Type Safety Improvements:

* [`src/hooks/useLoggableEvents.ts`](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L1-R5): Updated type imports to include `LoggableEventFragment`, ensuring proper type definitions for fragments used in the optimistic response logic.