### PR TITLE
grab labels from cache and input for optimistic responses

### DIFF
--- a/src/apollo/client.ts
+++ b/src/apollo/client.ts
@@ -27,7 +27,7 @@ const readLoggableEventFromCache = (eventId: string): LoggableEventFragment | nu
 /**
  * Helper function to read an EventLabel from the cache
  */
-const readEventLabelFromCache = (labelId: string): EventLabelFragment | null => {
+export const readEventLabelFromCache = (labelId: string): EventLabelFragment | null => {
     try {
         return cache.readFragment<EventLabelFragment>({
             id: `EventLabel:${labelId}`,


### PR DESCRIPTION
This pull request introduces changes to improve the handling of `labelIds` in the `useLoggableEvents` hook by leveraging cached data for labels. It also refactors the `readEventLabelFromCache` function to make it reusable across the codebase. The most important changes are grouped below.

### Refactoring and Reusability:
* Made the `readEventLabelFromCache` function reusable by exporting it from `src/apollo/client.ts`. This allows it to be utilized in other parts of the application.

### Enhancements to `useLoggableEvents` Hook:
* Updated the `optimisticResponse` logic in `useLoggableEvents` to fetch `labelIds` from the cache using `readEventLabelFromCache`, ensuring that labels are included in the optimistic response if provided. [[1]](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L208-R215) [[2]](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L217-R229)
* Modified the `update` logic in `useLoggableEvents` to conditionally fetch `labelIds` from the cache or preserve the existing labels, improving data consistency during updates. [[1]](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793R283-R289) [[2]](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L284-R299)

### Dependency Updates:
* Imported the `readEventLabelFromCache` function into `src/hooks/useLoggableEvents.ts` to enable its use in the `useLoggableEvents` hook.