### PR TITLE
add optimistic response for remove timestamps mutation

### DIFF
--- a/src/hooks/useLoggableEvents.ts
+++ b/src/hooks/useLoggableEvents.ts
@@ -305,10 +305,12 @@ export const useLoggableEvents = () => {
 
             if (!eventId) return IGNORE;
 
-            const existingEvent = client.cache.readFragment({
+            const existingEvent: LoggableEventFragment | null = client.cache.readFragment({
                 id: eventId,
                 fragment: USE_LOGGABLE_EVENTS_FRAGMENT
-            }) as LoggableEventFragment;
+            });
+
+            if (!existingEvent) return IGNORE;
 
             const labels = resolveLabelsFromCache(variables.input.labelIds, existingEvent.labels);
 
@@ -377,10 +379,12 @@ export const useLoggableEvents = () => {
 
             if (!eventId) return IGNORE;
 
-            const existingEvent = client.cache.readFragment({
+            const existingEvent: LoggableEventFragment | null = client.cache.readFragment({
                 id: eventId,
                 fragment: USE_LOGGABLE_EVENTS_FRAGMENT
-            }) as LoggableEventFragment;
+            });
+
+            if (!existingEvent) return IGNORE;
 
             const updatedTimestamps = Array.from(new Set([...existingEvent.timestamps, variables.input.timestamp]));
 
@@ -411,10 +415,12 @@ export const useLoggableEvents = () => {
 
                 if (!eventId) return IGNORE;
 
-                const existingEvent = client.cache.readFragment({
+                const existingEvent: LoggableEventFragment | null = client.cache.readFragment({
                     id: eventId,
                     fragment: USE_LOGGABLE_EVENTS_FRAGMENT
-                }) as LoggableEventFragment;
+                });
+
+                if (!existingEvent) return IGNORE;
 
                 const updatedTimestamps = existingEvent.timestamps.filter(
                     (timestamp: string) => timestamp !== variables.input.timestamp


### PR DESCRIPTION
This pull request enhances the `useLoggableEvents` functionality by improving label resolution logic and adding an optimistic response for timestamp removal. These changes aim to ensure better handling of cache updates and improve user experience during optimistic updates.

### Improvements to label resolution:

* [`src/hooks/useLoggableEvents.ts`](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L210-R230): Updated the `resolveLabelsFromCache` function to handle cases where some labels are missing from the cache. It now merges resolved labels with fallback labels to ensure optimistic updates work seamlessly, even when certain labels are not yet cached.

### Optimistic updates for timestamp removal:

* [`src/hooks/useLoggableEvents.ts`](diffhunk://#diff-3dfe228d69885863f7e7f95e6361744d6e7fef3aa32d43c2e1f5cdf9527c0793L387-R438): Added an `optimisticResponse` to the `REMOVE_TIMESTAMP_FROM_EVENT_MUTATION` in the `useLoggableEvents` hook. This ensures that the UI updates immediately when a timestamp is removed, by simulating the expected result of the mutation in the cache.