### PR TITLE
Change key for loggableeventcard from id to name to prevent flicker

### DIFF
--- a/src/components/LoggableEventsList.tsx
+++ b/src/components/LoggableEventsList.tsx
@@ -55,9 +55,9 @@ const LoggableEventsList = () => {
 
     return (
         <>
-            {filteredEventFragments.map(({ id }) => {
+            {filteredEventFragments.map(({ id, name }) => {
                 return (
-                    <Grid key={id} role="listitem">
+                    <Grid key={`event-${name}`} role="listitem">
                         <LoggableEventCard eventId={id} />
                     </Grid>
                 );


### PR DESCRIPTION
Change key for loggableeventcard from id to name to prevent flicker when creating a new event (a new event will temporarily have a temp id for an optimistic response and will get replaced by the actual event when the mutation resolves)