### PR TITLE
Cleanup update handler for createeevent mutation

### DIFF
--- a/src/hooks/useLoggableEvents.ts
+++ b/src/hooks/useLoggableEvents.ts
@@ -263,107 +263,40 @@ export const useLoggableEvents = () => {
         update: (cache, { data }) => {
             if (!data?.createLoggableEvent || !data.createLoggableEvent?.loggableEvent || !user?.id) return;
 
-            const tempID = data.createLoggableEvent.tempID;
-            const realEvent = data.createLoggableEvent.loggableEvent;
+            // Add new event to user's loggableEvents list
+            cache.modify({
+                id: cache.identify({ __typename: 'User', id: user.id }),
+                fields: {
+                    loggableEvents(existingEventRefs, { readField }) {
+                        const newEventRef = cache.writeFragment({
+                            fragment: USE_LOGGABLE_EVENTS_FRAGMENT,
+                            data: data.createLoggableEvent.loggableEvent
+                        });
 
-            // If we have a tempID that matches an existing temp event, we need to replace it
-            if (tempID && tempID.startsWith('temp-')) {
-                // Update the user's loggableEvents list
-                cache.modify({
-                    id: cache.identify({ __typename: 'User', id: user.id }),
-                    fields: {
-                        loggableEvents(existingEventRefs, { readField }) {
-                            // Safety checks. Not practically reachable so ignore them in coverage
-                            // istanbul ignore next
-                            if (!existingEventRefs) {
-                                const newEventRef = cache.writeFragment({
-                                    fragment: USE_LOGGABLE_EVENTS_FRAGMENT,
-                                    data: realEvent
-                                });
-                                return [newEventRef];
-                            }
+                        // Safety checks. Not practically reachable so ignore them in coverage
 
-                            // Check if we have a temp event to replace
-                            const tempEventIndex = existingEventRefs.findIndex(
-                                (ref: Reference) => readField('id', ref) === tempID
-                            );
+                        // If no existing events, return new event as the only ref
+                        // istanbul ignore next
+                        if (!existingEventRefs) return [newEventRef];
 
-                            if (tempEventIndex !== -1) {
-                                // Replace the temp event with the real one
-                                const newRefs = [...existingEventRefs];
-                                const newEventRef = cache.writeFragment({
-                                    fragment: USE_LOGGABLE_EVENTS_FRAGMENT,
-                                    data: realEvent
-                                });
+                        // If newEventRef is null, return existing refs
+                        // istanbul ignore next
+                        if (!newEventRef) return existingEventRefs;
 
-                                // istanbul ignore next
-                                if (!newEventRef) return existingEventRefs;
-
-                                newRefs[tempEventIndex] = newEventRef;
-
-                                // Remove the temp event from cache after replacing the reference
-                                cache.evict({ id: cache.identify({ __typename: 'LoggableEvent', id: tempID }) });
-
-                                return newRefs;
-                            } else {
-                                // No temp event found, check if real event already exists
-                                // istanbul ignore next
-                                if (existingEventRefs.some((ref: Reference) => readField('id', ref) === realEvent.id)) {
-                                    return existingEventRefs;
-                                }
-
-                                // Add as new event
-                                const newEventRef = cache.writeFragment({
-                                    fragment: USE_LOGGABLE_EVENTS_FRAGMENT,
-                                    data: realEvent
-                                });
-
-                                // istanbul ignore next
-                                if (!newEventRef) return existingEventRefs;
-
-                                return [...existingEventRefs, newEventRef];
-                            }
+                        // If event already exists, return existing refs
+                        // istanbul ignore next
+                        if (
+                            existingEventRefs.some(
+                                (ref: Reference) => readField('id', ref) === data.createLoggableEvent.loggableEvent.id
+                            )
+                        ) {
+                            return existingEventRefs;
                         }
+
+                        return [...existingEventRefs, newEventRef];
                     }
-                });
-            } else {
-                // No tempID - standard behavior
-                // Add new event to user's loggableEvents list
-                cache.modify({
-                    id: cache.identify({ __typename: 'User', id: user.id }),
-                    fields: {
-                        loggableEvents(existingEventRefs, { readField }) {
-                            const newEventRef = cache.writeFragment({
-                                fragment: USE_LOGGABLE_EVENTS_FRAGMENT,
-                                data: data.createLoggableEvent.loggableEvent
-                            });
-
-                            // Safety checks. Not practically reachable so ignore them in coverage
-
-                            // If no existing events, return new event as the only ref
-                            // istanbul ignore next
-                            if (!existingEventRefs) return [newEventRef];
-
-                            // If newEventRef is null, return existing refs
-                            // istanbul ignore next
-                            if (!newEventRef) return existingEventRefs;
-
-                            // If event already exists, return existing refs
-                            // istanbul ignore next
-                            if (
-                                existingEventRefs.some(
-                                    (ref: Reference) =>
-                                        readField('id', ref) === data.createLoggableEvent.loggableEvent.id
-                                )
-                            ) {
-                                return existingEventRefs;
-                            }
-
-                            return [...existingEventRefs, newEventRef];
-                        }
-                    }
-                });
-            }
+                }
+            });
         }
     });
 


### PR DESCRIPTION
The flickering issue is fixed from the last 2 PRs, cleaning up some unnecessary logic to simplify the update handler for createloggableevent mutation