### PR TITLE
Add option in labels autocomplete to create new label

### DIFF
--- a/src/components/EventCards/EventLabelAutocomplete.tsx
+++ b/src/components/EventCards/EventLabelAutocomplete.tsx
@@ -125,7 +125,7 @@ const EventLabelAutocomplete = ({ selectedLabels, setSelectedLabels, existingLab
             filterOptions={(options, params) => {
                 return getFilteredOptions(params.inputValue);
             }}
-            options={[]}
+            options={labelOptions.map(({ name }) => name)}
             value={selectedLabels.map(({ name }) => name)}
             onChange={(_, values, reason) => {
                 handleCreateNewLabelSelect(values);

--- a/src/components/EventCards/EventLabelAutocomplete.tsx
+++ b/src/components/EventCards/EventLabelAutocomplete.tsx
@@ -1,13 +1,19 @@
+import AddIcon from '@mui/icons-material/Add';
 import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import { InputBaseComponentProps } from '@mui/material/InputBase';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
+import invariant from 'tiny-invariant';
 
 import { useEventLabels, CreateEventLabelPayload } from '../../hooks/useEventLabels';
 import { EventLabel } from '../../utils/types';
 import { validateEventLabelName, MAX_LABEL_LENGTH } from '../../utils/validation';
 import { createEventLabelFromFragment } from '../EventLabels/EventLabel';
+
+const CREATE_NEW_LABEL_PREFIX = '__CREATE_NEW__';
 
 type Props = {
     selectedLabels: EventLabel[];
@@ -29,47 +35,104 @@ const EventLabelAutocomplete = ({ selectedLabels, setSelectedLabels, existingLab
     const labelOptions = existingLabels.filter((label) => !selectedLabels.some(({ id }) => id === label.id));
     const existingLabelNames = existingLabels.map((label) => label.name);
 
+    const getFilteredOptions = (inputValue: string) => {
+        let filteredOptions = labelOptions
+            .filter((label) => label.name.toLowerCase().includes(inputValue.toLowerCase()))
+            .map(({ name }) => name);
+
+        // Add "Create new label" option if input doesn't match any existing label and is valid
+        if (inputValue && !existingLabelNames.some((name) => name.toLowerCase() === inputValue.toLowerCase())) {
+            const validationError = validateEventLabelName(inputValue, existingLabelNames);
+            if (validationError === null) {
+                filteredOptions = [...filteredOptions, `${CREATE_NEW_LABEL_PREFIX}${inputValue}`];
+            }
+        }
+
+        return filteredOptions;
+    };
+
+    const handleCreateNewLabel = (labelName: string) => {
+        const validationError = validateEventLabelName(labelName, existingLabelNames);
+        if (validationError === null) {
+            const onCompleted = (payload: { createEventLabel: CreateEventLabelPayload }) => {
+                const newLabel = createEventLabelFromFragment(payload.createEventLabel.eventLabel);
+                setSelectedLabels((prev) => [...prev, newLabel]);
+            };
+            createEventLabel({ name: labelName }, onCompleted);
+        }
+    };
+
     return (
         <Autocomplete
             multiple
             freeSolo
-            options={labelOptions.map(({ name }) => name)}
+            filterOptions={(options, params) => {
+                return getFilteredOptions(params.inputValue);
+            }}
+            options={[]}
             value={selectedLabels.map(({ name }) => name)}
             onChange={(_, values, reason) => {
-                // Handle label creation separately from selection
+                // Handle "Create new label" selection
+                const createNewValues = values.filter((val: string) => val.startsWith(CREATE_NEW_LABEL_PREFIX));
+                createNewValues.forEach((val: string) => {
+                    const labelName = val.replace(CREATE_NEW_LABEL_PREFIX, '');
+                    handleCreateNewLabel(labelName);
+                });
+
+                // Handle label creation separately from selection (for freeSolo input)
                 const newLabelsToCreate = values.filter(
                     (val: string) =>
                         reason === 'createOption' &&
+                        !val.startsWith(CREATE_NEW_LABEL_PREFIX) &&
                         !existingLabelNames.includes(val) &&
                         !selectedLabels.some((label) => label.name === val)
                 );
 
                 // Create new labels if needed
                 newLabelsToCreate.forEach((val: string) => {
-                    const validationError = validateEventLabelName(val, existingLabelNames);
-                    if (validationError === null) {
-                        const onCompleted = (payload: { createEventLabel: CreateEventLabelPayload }) => {
-                            const newLabel = createEventLabelFromFragment(payload.createEventLabel.eventLabel);
-                            setSelectedLabels((prev) => [...prev, newLabel]);
-                        };
-                        createEventLabel({ name: val }, onCompleted);
-                    }
+                    handleCreateNewLabel(val);
                 });
 
-                // Update selected labels with existing labels only
+                // Update selected labels with existing labels only (filter out create new options)
                 const existingSelectedLabels = values
+                    .filter((val: string) => !val.startsWith(CREATE_NEW_LABEL_PREFIX))
                     .map((val: string) => existingLabels.find((label) => label.name === val))
                     .filter((label): label is EventLabel => label !== undefined);
 
                 setSelectedLabels(existingSelectedLabels);
             }}
             renderValue={(value, getTagProps) =>
-                value.map((option, index) => {
-                    const label = existingLabels.find((label) => label.name === option);
-                    if (!label) return null;
-                    return <Chip label={label.name} size="small" {...getTagProps({ index })} key={label.id} />;
-                })
+                value
+                    .filter((option) => existingLabels.some((label) => label.name === option))
+                    .map((option, index) => {
+                        const label = existingLabels.find((label) => label.name === option);
+                        invariant(label, `Label not found for option: ${option}`);
+                        return (
+                            <Chip
+                                label={label.name}
+                                size="small"
+                                {...getTagProps({ index })}
+                                key={`chip-${label.name}`}
+                            />
+                        );
+                    })
             }
+            renderOption={(props, option) => {
+                if (option.startsWith(CREATE_NEW_LABEL_PREFIX)) {
+                    const labelName = option.replace(CREATE_NEW_LABEL_PREFIX, '');
+                    return (
+                        <Box component="li" {...props} key={option}>
+                            <AddIcon sx={{ mr: 1, color: 'primary.main' }} />
+                            <Typography variant="body2">Create new label: {labelName}</Typography>
+                        </Box>
+                    );
+                }
+                return (
+                    <Box component="li" {...props} key={option}>
+                        <Typography variant="body2">{option}</Typography>
+                    </Box>
+                );
+            }}
             renderInput={(params) => {
                 const inputValue = (params.inputProps as InputBaseComponentProps).value || '';
                 let error = false;

--- a/src/components/EventCards/EventLabelAutocomplete.tsx
+++ b/src/components/EventCards/EventLabelAutocomplete.tsx
@@ -79,11 +79,10 @@ const EventLabelAutocomplete = ({ selectedLabels, setSelectedLabels, existingLab
      * @param values - Array of selected values from the autocomplete
      */
     const handleCreateNewLabelSelect = (values: readonly string[]) => {
-        const createNewValues = values.filter((val: string) => val.startsWith(CREATE_NEW_LABEL_PREFIX));
-        createNewValues.forEach((val: string) => {
-            const labelName = val.replace(CREATE_NEW_LABEL_PREFIX, '');
-            createNewLabel(labelName);
-        });
+        const newLabelsToCreate = values
+            .filter((val: string) => val.startsWith(CREATE_NEW_LABEL_PREFIX))
+            .map((val: string) => val.replace(CREATE_NEW_LABEL_PREFIX, ''));
+        newLabelsToCreate.forEach((labelName: string) => createNewLabel(labelName));
     };
 
     /**

--- a/src/hooks/useEventLabels.ts
+++ b/src/hooks/useEventLabels.ts
@@ -142,7 +142,7 @@ export const useEventLabels = () => {
                 tempID: variables.input.id,
                 eventLabel: {
                     __typename: 'EventLabel',
-                    id: `temp-${uuidv4()}`,
+                    id: variables.input.id,
                     name: variables.input.name
                 },
                 errors: []


### PR DESCRIPTION
This pull request introduces enhancements to the `EventLabelAutocomplete` component, enabling users to create new event labels directly from the autocomplete dropdown. It also refactors the `useEventLabels` hook to ensure consistent handling of label IDs. The most significant changes include adding a "Create new label" option, improving label validation, and updating the rendering logic for autocomplete options.

### Enhancements to `EventLabelAutocomplete`:

* Added a "Create new label" option in the autocomplete dropdown when the input does not match any existing label and passes validation. This includes the `CREATE_NEW_LABEL_PREFIX` constant and the `handleCreateNewLabel` function for label creation. (`src/components/EventCards/EventLabelAutocomplete.tsx`, [[1]](diffhunk://#diff-47a848dfda1208c36c971c88790411594b5fde5b864ccd31480cd31fc874bcc9R1-R17) [[2]](diffhunk://#diff-47a848dfda1208c36c971c88790411594b5fde5b864ccd31480cd31fc874bcc9R38-R135)
* Updated the `filterOptions` logic to dynamically include the "Create new label" option based on user input. (`src/components/EventCards/EventLabelAutocomplete.tsx`, [src/components/EventCards/EventLabelAutocomplete.tsxR38-R135](diffhunk://#diff-47a848dfda1208c36c971c88790411594b5fde5b864ccd31480cd31fc874bcc9R38-R135))
* Improved rendering of autocomplete options to visually distinguish between existing labels and the "Create new label" option using icons and typography. (`src/components/EventCards/EventLabelAutocomplete.tsx`, [src/components/EventCards/EventLabelAutocomplete.tsxR38-R135](diffhunk://#diff-47a848dfda1208c36c971c88790411594b5fde5b864ccd31480cd31fc874bcc9R38-R135))

### Refactoring in `useEventLabels`:

* Updated the `useEventLabels` hook to use the input ID directly for temporary event labels, ensuring consistency in ID handling. (`src/hooks/useEventLabels.ts`, [src/hooks/useEventLabels.tsL145-R145](diffhunk://#diff-ff6763c21142d81a7f2964f32be8733d3c67d6aaa0132cad26fd6164574c9d36L145-R145))


<img width="439" height="297" alt="image" src="https://github.com/user-attachments/assets/198b2fd9-fef2-4490-ac43-50ebb3f6b289" />
