### PR TITLE
Add user-event v14 and update tests for EventLabel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,25 +182,39 @@ Use `@testing-library/user-event` for more realistic user interactions:
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-// Click interactions
-await userEvent.click(screen.getByRole('button', { name: /save/i }));
+describe('ComponentName', () => {
+  let user;
 
-// Type interactions
-await userEvent.type(screen.getByLabelText(/name/i), 'New Name');
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
 
-// Clear and type
-await userEvent.clear(screen.getByLabelText(/email/i));
-await userEvent.type(screen.getByLabelText(/email/i), 'test@example.com');
+  it('handles user interactions', async () => {
+    renderWithProviders(<Component />);
 
-// Select text in input
-await userEvent.selectOptions(screen.getByRole('combobox'), ['option-value']);
+    // Click interactions
+    await user.click(screen.getByRole('button', { name: /save/i }));
 
-// Hover interactions
-await userEvent.hover(screen.getByText('Hover me'));
-await userEvent.unhover(screen.getByText('Hover me'));
+    // Type interactions
+    await user.type(screen.getByLabelText(/name/i), 'New Name');
+
+    // Clear and type
+    await user.clear(screen.getByLabelText(/email/i));
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+
+    // Select text in input
+    await user.selectOptions(screen.getByRole('combobox'), ['option-value']);
+
+    // Hover interactions
+    await user.hover(screen.getByText('Hover me'));
+    await user.unhover(screen.getByText('Hover me'));
+
+    // Keyboard interactions
+    await user.keyboard('{Enter}');
+    await user.keyboard('{Escape}');
+  });
+});
 ```
-
-**Note**: This project uses an older version of userEvent that doesn't support `.setup()`. Use the direct methods as shown above.
 
 #### When to use fireEvent
 Only use fireEvent for edge cases where userEvent doesn't support the interaction:
@@ -334,7 +348,7 @@ it('shows content when expanded', async () => {
   expect(screen.getByTestId('collapsible-content')).not.toBeVisible();
   
   // Click to expand
-  await userEvent.click(toggleButton);
+  await user.click(toggleButton);
   
   // Content should now be visible
   expect(screen.getByTestId('collapsible-content')).toBeVisible();
@@ -373,7 +387,7 @@ await waitFor(() => {
 });
 
 // For userEvent async operations
-await userEvent.click(submitButton);
+await user.click(submitButton);
 await waitFor(() => {
   expect(screen.getByText('Success')).toBeInTheDocument();
 });
@@ -387,16 +401,6 @@ The project uses Material-UI which can cause "act" warnings in tests. These are 
 #### TypeScript in Tests
 Test files use `.js` extension but can still import TypeScript files. Type checking is not enforced in test files.
 
-#### Older userEvent Version
-This project uses an older version of `@testing-library/user-event` that doesn't support the `.setup()` pattern. Use the direct methods instead:
-```javascript
-// Don't do this (newer version)
-const user = userEvent.setup();
-await user.click(button);
-
-// Do this instead (older version)
-await userEvent.click(button);
-```
 
 ### 10. Running Tests
 ```bash
@@ -424,12 +428,12 @@ it('accepts current date when picker is used', async () => {
   renderWithProviders();
   
   const dateInput = screen.getByLabelText(/event date/i);
-  await userEvent.click(dateInput);
+  await user.click(dateInput);
   
   // Interact with the actual MUI dialog
   const okButton = await screen.findByRole('button', { name: /ok/i });
   if (okButton) {
-    await userEvent.click(okButton);
+    await user.click(okButton);
     expect(mockOnAccept).toHaveBeenCalled();
   }
 });

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "devDependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^8.35.1",
         "@typescript-eslint/parser": "^8.35.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2925,14 +2925,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:^13.5.0":
-  version: 13.5.0
-  resolution: "@testing-library/user-event@npm:13.5.0"
-  dependencies:
-    "@babel/runtime": ^7.12.5
+"@testing-library/user-event@npm:^14.6.1":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
   peerDependencies:
     "@testing-library/dom": ">=7.21.4"
-  checksum: 16319de685fbb7008f1ba667928f458b2d08196918002daca56996de80ef35e6d9de26e9e1ece7d00a004692b95a597cf9142fff0dc53f2f51606a776584f549
+  checksum: 4cb8a81fea1fea83a42619e9545137b51636bb7a3182c596bb468e5664f1e4699a275c2d0fb8b6dcc3fe2684f9d87b0637ab7cb4f566051539146872c9141fcb
   languageName: node
   linkType: hard
 
@@ -9685,7 +9683,7 @@ __metadata:
     "@react-oauth/google": ^0.12.2
     "@testing-library/jest-dom": ^5.16.4
     "@testing-library/react": ^13.2.0
-    "@testing-library/user-event": ^13.5.0
+    "@testing-library/user-event": ^14.6.1
     "@types/jest": ^27.5.1
     "@types/node": ^17.0.33
     "@types/react": ^18.0.9


### PR DESCRIPTION
This pull request updates the testing approach by upgrading `@testing-library/user-event` to a newer version and refactoring tests to use the `.setup()` pattern for more realistic user interactions. Additionally, it introduces improvements to the `EventLabel` component tests, including better mocking and enhanced functionality for handling label updates and deletions.

### Testing Improvements:
* Updated `@testing-library/user-event` dependency from version `^13.5.0` to `^14.6.1` in `package.json`, enabling the `.setup()` pattern for user interactions.
* Refactored tests across `CLAUDE.md` to use the `.setup()` pattern for user interactions, replacing direct method calls (`userEvent.click`, `userEvent.type`, etc.) with `user.click`, `user.type`, and similar methods. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R185-R217) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L337-R351) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L376-R390) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L427-R436)

### `EventLabel` Component Enhancements:
* Added Apollo Client's `MockedProvider` and `InMemoryCache` for prepopulating test data, enabling more robust and isolated tests for the `EventLabel` component. [[1]](diffhunk://#diff-4d3a44110246e027a0b09878c14e3205c973cdb764a9ea1ec720efc2279b6455R1-R30) [[2]](diffhunk://#diff-4d3a44110246e027a0b09878c14e3205c973cdb764a9ea1ec720efc2279b6455R40-R58)
* Refactored `EventLabel` tests to pass `eventLabelId` and `existingLabelNames` props explicitly, improving clarity and flexibility in test cases. [[1]](diffhunk://#diff-4d3a44110246e027a0b09878c14e3205c973cdb764a9ea1ec720efc2279b6455L38-L91) [[2]](diffhunk://#diff-4d3a44110246e027a0b09878c14e3205c973cdb764a9ea1ec720efc2279b6455L100-R155) [[3]](diffhunk://#diff-4d3a44110246e027a0b09878c14e3205c973cdb764a9ea1ec720efc2279b6455L118-R255)
* Improved event handling in tests, including support for keyboard interactions (e.g., pressing `Enter` or `Escape`) and validation for invalid label names during editing.
* Enhanced mocking of `useEventLabels` hook to simulate loading states and provide more realistic test scenarios.

<img width="578" height="344" alt="image" src="https://github.com/user-attachments/assets/084f15fb-ec96-4bda-bbf5-760367eaf7e3" />
